### PR TITLE
Correct identity map parameter type

### DIFF
--- a/api/v1/endpoints/post-identity-map.md
+++ b/api/v1/endpoints/post-identity-map.md
@@ -15,8 +15,8 @@ Integration workflows that use this endpoint:
 
 | Property | Data Type | Attributes | Description |
 | --- | --- | --- | --- |
-| `email` | `string` | Conditionally Required | The [normalized email address](../../README.md#emailnormalization) of a user. Required when `email_hash` is not included in the request. |
-| `email_hash` | `string` | Conditionally Required | The [base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md#emailnormalization) of a user. Required when `email` is not included in the request. |
+| `email` | `[string]` | Conditionally Required | The [normalized email address](../../README.md#emailnormalization) of a user. Required when `email_hash` is not included in the request. |
+| `email_hash` | `[string]` | Conditionally Required | The [base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md#emailnormalization) of a user. Required when `email` is not included in the request. |
 
 If `email` and `email_hash` are both supposed in the same request, only the `email` will return a mapping response.
 


### PR DESCRIPTION
For `POST /identity/map`, the current doc states that both `email` and `email_hash` are `string` type but from the description, it should be an array of `string` instead..

I've tried call the current API server with just a single email `string`, and it returned HTTP status 500 with following body:

```json
{"message":"Unknown State","status":"unknown"}
```

So to make it clear, I updated the doc to reflect the necessity of wrapped as an array.