### PR TITLE
Fix #email-normalization links

### DIFF
--- a/api/v1/endpoints/get-identity-map.md
+++ b/api/v1/endpoints/get-identity-map.md
@@ -15,8 +15,8 @@ Integration workflows that use this endpoint:
 
 | Query Parameter | Data Type | Attributes | Description |
 | --- | --- | --- | --- |
-| `email` | `string` | Conditionally Required | The [normalized email address](../../README.md#emailnormalization) of a user. Required when `email_hash` is not included in the request. |
-| `email_hash` | `string` | Conditionally Required | The [URL-encoded, base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md#emailnormalization) of a user. Required when `email` is not included in the request. |
+| `email` | `string` | Conditionally Required | The [normalized email address](../../README.md##email-normalization) of a user. Required when `email_hash` is not included in the request. |
+| `email_hash` | `string` | Conditionally Required | The [URL-encoded, base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md##email-normalization) of a user. Required when `email` is not included in the request. |
 
 If `email` and `email_hash` are both supposed in the same request, only the `email` will return a mapping response.
 

--- a/api/v1/endpoints/get-token-generate.md
+++ b/api/v1/endpoints/get-token-generate.md
@@ -15,8 +15,8 @@ Integration workflows that use this endpoint:
 
 | Query Parameter | Data Type | Attributes | Description |
 | --- | --- | --- | --- |
-| `email` | `string` | Conditionally Required | The [normalized email address](../../README.md#emailnormalization) of a user. Required when `email_hash` is not included in the request. |
-| `email_hash` | `string` | Conditionally Required | The [URL-encoded, base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md#emailnormalization) of a user. Required when `email` is not included in the request. |
+| `email` | `string` | Conditionally Required | The [normalized email address](../../README.md##email-normalization) of a user. Required when `email_hash` is not included in the request. |
+| `email_hash` | `string` | Conditionally Required | The [URL-encoded, base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md##email-normalization) of a user. Required when `email` is not included in the request. |
 
 If `email` and `email_hash` are both supplied in the same request, only the `email` will return a mapping response.
 

--- a/api/v1/endpoints/post-identity-map.md
+++ b/api/v1/endpoints/post-identity-map.md
@@ -15,8 +15,8 @@ Integration workflows that use this endpoint:
 
 | Property | Data Type | Attributes | Description |
 | --- | --- | --- | --- |
-| `email` | `string` | Conditionally Required | The [normalized email address](../../README.md#emailnormalization) of a user. Required when `email_hash` is not included in the request. |
-| `email_hash` | `string` | Conditionally Required | The [base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md#emailnormalization) of a user. Required when `email` is not included in the request. |
+| `email` | `string` | Conditionally Required | The [normalized email address](../../README.md##email-normalization) of a user. Required when `email_hash` is not included in the request. |
+| `email_hash` | `string` | Conditionally Required | The [base64-encoded SHA256 hash](../../README.md#encoding-email-hashes) of the [normalized email address](../../README.md##email-normalization) of a user. Required when `email` is not included in the request. |
 
 If `email` and `email_hash` are both supposed in the same request, only the `email` will return a mapping response.
 

--- a/api/v1/guides/custom-publisher-integration.md
+++ b/api/v1/guides/custom-publisher-integration.md
@@ -16,7 +16,7 @@ This section focuses on publisher-specific steps 1-d, 1-e, and 1-f illustrated i
 
 | Step | Endpoint/SDK | Instruction |
 | --- | --- | --- |
-| d | [GET /token/generate](../endpoints/get-token-generate.md) | There are two ways for publishers to establish identity with UID2.<br>1. Integrate with a UID2-enabled single-sign-on provider.<br>2. Generate UID2 tokens when a user authenticates using the [GET /token/generate](../endpoints/get-token-generate.md) endpoint. The request includes a user's normalized email address or the base64-encoded SHA256 hash of the user's normalized email address. [Click here to view email normalization rules.](../../README.md#emailnormalization) |
+| d | [GET /token/generate](../endpoints/get-token-generate.md) | There are two ways for publishers to establish identity with UID2.<br>1. Integrate with a UID2-enabled single-sign-on provider.<br>2. Generate UID2 tokens when a user authenticates using the [GET /token/generate](../endpoints/get-token-generate.md) endpoint. The request includes a user's normalized email address or the base64-encoded SHA256 hash of the user's normalized email address. [Click here to view email normalization rules.](../../README.md##email-normalization) |
 | e | [GET /token/generate](../endpoints/get-token-generate.md) | The token generation service returns UID2 tokens. |
 | f |  | Place the returned `advertising_token` and `refresh_token` in a store tied to a user. You may consider client-side storage like a first-party cookie or server-side storage. |
 


### PR DESCRIPTION
As titled, the right anchor name of README's email normalization is `#email-normalization`.