### PR TITLE
Correct callback property name

### DIFF
--- a/api/v2/sdks/client-side-identity.md
+++ b/api/v2/sdks/client-side-identity.md
@@ -165,7 +165,7 @@ The `object` parameter includes the following properties.
 
 | Property | Data Type | Description |
 | :--- | :--- | :--- |
-| `advertisingToken` | string | The token to be passed to SSPs for targeted advertising. If the token/identity is invalid or unavailable, the value is `undefined`. |
+| `advertising_token` | string | The token to be passed to SSPs for targeted advertising. If the token/identity is invalid or unavailable, the value is `undefined`. |
 | `status` | `UID2.IdentityStatus` enum | The numeric value that indicates the status of the identity. For details, see [Identity Status Values](#identity-status-values). |
 | `statusText` | string | Additional information pertaining to the identity status. |
 


### PR DESCRIPTION
Accoding to the [SDK source code](https://prod.uidapi.com/static/js/uid2-sdk-2.0.0.js):

```js
const updateStatus = (status, statusText) => {
    _lastStatus = status;

    const promises = _promises;
    _promises = [];

    const advertisingToken = this.getAdvertisingToken();

    const result = {
        advertising_token: advertisingToken,
        status: status,
        statusText: statusText
    };
    _opts.callback(result);

    if (advertisingToken) {
        promises.forEach(p => p.resolve(advertisingToken));
    } else {
        promises.forEach(p => p.reject(new Error(statusText)));
    }
};
```

The correct property name should be `advertising_token` instead of `advertisingToken`.