### PR TITLE
fix phone hashing examples

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -69,8 +69,8 @@ Phone number hashes are base64-encoded SHA256 hashes of a normalized phone numbe
 | Type | Example | Comments and Usage |
 | :--- | :--- | :--- |
 | Normalized phone number | `+12345678901` | N/A |
-| SHA256 of phone number | `c1d3756a586b6f0d419b3e3d1b328674fbc6c4b842367ee7ded780390fc548ae` |This 64-character string is a hex-encoded representation of 32-byte SHA256. |
-| base64-encoded SHA256 of phone number | `wdN1alhrbw1Bmz49GzKGdPvGxLhCNn7n3teAOQ/FSK4=` | This 44-character string is a base64-encoded representation of 32-byte SHA256.<br/>Use this encoding for `phone_hash` values sent in the request body. |
+| SHA256 of phone number | `10e6f0b47054a83359477dcb35231db6de5c69fb1816e1a6b98e192de9e5b9ee` |This 64-character string is a hex-encoded representation of 32-byte SHA256. |
+| base64-encoded SHA256 of phone number | `EObwtHBUqDNZR33LNSMdtt5cafsYFuGmuY4ZLenlue4=` | This 44-character string is a base64-encoded representation of 32-byte SHA256.<br/>Use this encoding for `phone_hash` values sent in the request body. |
 
 ## License
 All work and artifacts are licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).


### PR DESCRIPTION
The SHA256 and base64 examples appeared incorrect according to https://emn178.github.io/online-tools/sha256.html , as well as when debugging Operator manually.