### PR TITLE
Update docs for Mobile SDK v2 releases

### DIFF
--- a/docs/guides/integration-mobile-client-server.md
+++ b/docs/guides/integration-mobile-client-server.md
@@ -326,7 +326,9 @@ UID2Manager.shared.automaticRefreshEnabled = false
 ## Optional: UID2 Integration with Prebid Mobile SDK
 
 :::important
-The UID2 integration with Prebid Mobile SDK requires version 1.6.0 of the UID2 SDK for Android, or version 1.7.0 of the UID2 SDK for iOS.
+The UID2 integration with Prebid Mobile SDK v2 requires version 1.6.0 of the UID2 SDK for Android, or version 1.7.0 of the UID2 SDK for iOS.
+
+If you are using Prebid Mobile SDK v3, version 2.0.0 of the UID2 SDK for Android or iOS is required.
 :::
 
 <PrebidMobileSDK />

--- a/docs/guides/integration-mobile-client-side.md
+++ b/docs/guides/integration-mobile-client-side.md
@@ -737,7 +737,9 @@ If the response status indicates that the DII has been opted out of UID2, you mi
 ## Optional: UID2 Integration with Prebid Mobile SDK
 
 :::important
-The UID2 integration with Prebid Mobile SDK requires version 1.6.0 of the UID2 SDK for Android, or version 1.7.0 of the UID2 SDK for iOS.
+The UID2 integration with Prebid Mobile SDK v2 requires version 1.6.0 of the UID2 SDK for Android, or version 1.7.0 of the UID2 SDK for iOS.
+
+If you are using Prebid Mobile SDK v3, version 2.0.0 of the UID2 SDK for Android or iOS is required.
 :::
 
 <PrebidMobileSDK />

--- a/docs/guides/mobile-plugin-gma-android.md
+++ b/docs/guides/mobile-plugin-gma-android.md
@@ -18,9 +18,9 @@ This plugin simplifies integration with Google Mobile Ads (GMA) for any publishe
 
 ## Version
 
-<!-- As of 2024-10-23 -->
+<!-- As of 2025-08-07 -->
 
-This documentation is for the UID2 GMA Plugin for Android version 1.6.0 and later.
+This documentation is for the UID2 GMA Plugin for Android version 2.0.0 and later.
 
 ## GitHub Repository
 
@@ -43,17 +43,17 @@ To run this plugin, install the following:
 1. Google Mobile Ads SDK v22.0.0 or later:
    - [SDK](https://developers.google.com/admob/android/sdk)
    - [Release notes](https://developers.google.com/admob/android/rel-notes)
-1. SDK for Android v1.6.0 or later:
+1. SDK for Android v2.0.0 or later:
    - [SDK](https://central.sonatype.com/artifact/com.uid2/uid2-android-sdk)
    - [SDK for Android Reference Guide](../sdks/sdk-ref-android.md)
-1. [UID2 Android GMA Plugin v1.6.0](https://central.sonatype.com/artifact/com.uid2/uid2-android-sdk-gma/)
+1. [UID2 Android GMA Plugin v2.0.0](https://central.sonatype.com/artifact/com.uid2/uid2-android-sdk-gma/)
 1. If you are using R8 or Proguard, add the applicable option specified in [Notes for Using R8 or ProGuard](#notes-for-using-r8-or-proguard)
 
 ## Installation
 
 Prerequisite: Install the Google Mobile Ads SDK and the SDK for Android.
 
-Install the UID2 Android GMA Plugin v1.6.0 to an existing app with the SDK for Android and Google GMA SDK installed. There are two installation options:
+Install the UID2 Android GMA Plugin v2.0.0 to an existing app with the SDK for Android and Google GMA SDK installed. There are two installation options:
 
 - [Gradle](#gradle)
 - [Maven](#maven)
@@ -63,7 +63,7 @@ Install the UID2 Android GMA Plugin v1.6.0 to an existing app with the SDK for A
 To install with Gradle, add the SDK as a dependency in the `build.gradle` file:
 
 ```js
-implementation 'com.uid2:uid2-android-sdk-gma:1.6.0'
+implementation 'com.uid2:uid2-android-sdk-gma:2.0.0'
 ```
 
 ### Maven 
@@ -74,7 +74,7 @@ To install with Maven, add the SDK as a dependency in the `pom.xml` file:
 <dependency>
   <groupId>com.uid2</groupId>
   <artifactId>uid2-android-sdk-gma</artifactId>
-  <version>1.6.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 

--- a/docs/guides/mobile-plugin-ima-android.md
+++ b/docs/guides/mobile-plugin-ima-android.md
@@ -18,9 +18,9 @@ This plugin simplifies integration with Google Interactive Media Ads (IMA) for a
 
 ## Version
 
-<!-- As of 2024-10-23 -->
+<!-- As of 2025-08-07 -->
 
-This documentation is for the UID2 IMA Plugin for Android version 1.6.0 and later.
+This documentation is for the UID2 IMA Plugin for Android version 2.0.0 and later.
 
 ## GitHub Repository
 
@@ -43,10 +43,10 @@ To run this plugin, install the following:
 1. Google IMA SDK v3.30.3 or later:
    - [SDK](https://developers.google.com/interactive-media-ads/docs/sdks/android/client-side)
    - [Release history](https://developers.google.com/interactive-media-ads/docs/sdks/android/client-side/history)
-1. SDK for Android v1.6.0 or later:
+1. SDK for Android v2.0.0 or later:
    - [SDK](https://central.sonatype.com/artifact/com.uid2/uid2-android-sdk)
    - [SDK for Android Reference Guide](../sdks/sdk-ref-android.md)
-1. [UID2 IMA Plugin for Android v1.6.0](https://central.sonatype.com/artifact/com.uid2/uid2-android-sdk-ima)
+1. [UID2 IMA Plugin for Android v2.0.0](https://central.sonatype.com/artifact/com.uid2/uid2-android-sdk-ima)
 1. If you are using R8 or Proguard, add the applicable option specified in [Notes for Using R8 or ProGuard](#notes-for-using-r8-or-proguard)
 
 ## Installation
@@ -63,7 +63,7 @@ Install the UID2 Android IMA Plugin to an existing app with the SDK for Android 
 To install with Gradle, add the SDK as a dependency in the `build.gradle` file:
 
 ```js
-implementation 'com.uid2:uid2-android-sdk-ima:1.6.0'
+implementation 'com.uid2:uid2-android-sdk-ima:2.0.0'
 ```
 
 ### Maven
@@ -74,7 +74,7 @@ To install with Maven, add the SDK as a dependency in the `pom.xml` file:
 <dependency>
   <groupId>com.uid2</groupId>
   <artifactId>uid2-android-sdk-ima</artifactId>
-  <version>1.6.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 

--- a/docs/sdks/sdk-ref-android.md
+++ b/docs/sdks/sdk-ref-android.md
@@ -54,9 +54,9 @@ The steps you'll take in the UID2 Portal are different depending on whether your
 
 ## SDK Version
 
-<!-- As of 23 Oct 2024 -->
+<!-- As of 2025-08-07 -->
 
-This documentation is for the SDK for Android version 1.6.0 and later.
+This documentation is for the SDK for Android version 2.0.0 and later.
 
 For current and past release notes information, see [https://github.com/IABTechLab/uid2-android-sdk/releases](https://github.com/IABTechLab/uid2-android-sdk/releases).
 
@@ -98,7 +98,7 @@ To install with Gradle, add the SDK as a dependency in the build.gradle
 file:
 
 ```js
-implementation 'com.uid2:uid2-android-sdk:1.6.0'
+implementation 'com.uid2:uid2-android-sdk:2.0.0'
 ```
 
 ### Installing with Maven 
@@ -109,7 +109,7 @@ To install with Maven, add the SDK as a dependency in the `pom.xml` file:
 <dependency> 
   <groupId>com.uid2</groupId> 
   <artifactId>uid2-android-sdk</artifactId> 
-  <version>1.6.0</version> 
+  <version>2.0.0</version> 
 </dependency> 
 ```
 

--- a/docs/sdks/sdk-ref-ios.md
+++ b/docs/sdks/sdk-ref-ios.md
@@ -51,9 +51,9 @@ The steps you'll take in the UID2 Portal are different depending on whether your
 
 ## SDK Version
 
-<!-- As of 22 Oct 2024 -->
+<!-- As of 2025-08-07 -->
 
-This documentation is for the SDK for iOS version 1.7.0 or later.
+This documentation is for the SDK for iOS version 2.0.0 or later.
 
 For current and past release notes information, see [https://github.com/IABTechLab/uid2-ios-sdk/releases](https://github.com/IABTechLab/uid2-ios-sdk/releases).
 
@@ -90,7 +90,7 @@ Add the following dependency to Package.swift:
 
 ```js
 dependencies: [
-  .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "1.7.0"),
+  .package(url: "https://github.com/IABTechLab/uid2-ios-sdk.git", from: "2.0.0"),
 ]
 ```
 
@@ -100,14 +100,14 @@ In the XCode user interface, under Package Dependencies, add the following entry
 
 | Name | Location | Dependency Rule |
 | :--- | :--- | :--- |
-| uid2-ios-sdk | `git@github.com:IABTechLab/uid2-ios-sdk.git` | Up to next major version: 1.7.0 < 2.0.0 |
+| uid2-ios-sdk | `git@github.com:IABTechLab/uid2-ios-sdk.git` | Up to next major version: 2.0.0 < 3.0.0 |
 
 ### Installing with CocoaPods
 
 Add the following entry in your `Podfile`:
 
 ```
-pod 'UID2', '~> 1.7'
+pod 'UID2', '~> 2.0'
 ```
 
 ## Usage Guidelines

--- a/docs/snippets/_mobile_docs_prebid-mobile.mdx
+++ b/docs/snippets/_mobile_docs_prebid-mobile.mdx
@@ -23,7 +23,7 @@ To configure your UID2 Prebid for Mobile integration, follow these steps:
    <TabItem value='gradle' label='Gradle (Android)'>
    Include the following in your Gradle configuration:
    ```js
-   implementation("com.uid2:uid2-android-sdk-prebid:1.6.0")
+   implementation("com.uid2:uid2-android-sdk-prebid:2.0.0")
    ```
    </TabItem>
    <TabItem value='maven' label='Maven (Android)'>
@@ -32,20 +32,22 @@ To configure your UID2 Prebid for Mobile integration, follow these steps:
    <dependency>
       <groupId>com.uid2</groupId>
       <artifactId>uid2-android-sdk-prebid</artifactId>
-      <version>1.6.0</version>
+      <version>2.0.0</version>
    </dependency>
    ```
    </TabItem>
    <TabItem value='cocoapods' label='CocoaPods (iOS)'>
    Add the following entry in your `Podfile`:
    ```js
-   pod 'UID2Prebid', '~> 1.7'
+   pod 'UID2Prebid', '~> 2.0'
    ```
    </TabItem>
    <TabItem value='spm' label='SPM (iOS)'>
-   :::warning
-   Integration via Swift Package Manager is not supported until it is supported by the Prebid Mobile SDK itself. For details, see [Prebid's Mobile SDK documentation](https://docs.prebid.org/prebid-mobile/pbm-api/ios/code-integration-ios.html#swift-pm).
-   :::
+   In the XCode user interface, under Package Dependencies, add the following url and choose to add `UID2Prebid` to your target.
+   
+   ```js
+   https://github.com/IABTechLab/uid2-ios-sdk.git
+   ```
    </TabItem>
    </Tabs>
 


### PR DESCRIPTION
Update docs ahead of Android and iOS 2.0.0 releases, which only contains breaking changes to the `UID2Prebid` module. 

The main change is in the following two files where we detail version numbers for Prebid integration:
- docs/guides/integration-mobile-client-server.md
- docs/guides/integration-mobile-client-side.md

Most other changes are simply to reference version 2.0.0 as the latest version. 