### PR TITLE
UID2-6960: Back-fill token validator doc edits + Documentation Updates entry

### DIFF
--- a/docs/ref-info/ref-token-validator.md
+++ b/docs/ref-info/ref-token-validator.md
@@ -14,7 +14,7 @@ The [UID2 Token Validator](https://token-validator.uidapi.com/) is a web-based t
 
 ## Overview
 
-Publishers who generate UID2 tokens by providing DII sometimes receive tokens that appear valid but are unusable in the UID2 ecosystem. This happens when the normalization or hashing steps are not performed correctly. Because UID2 uses the normalized and hashed form of DII to derive the token, an error in either step produces a <Link href="../ref-info/glossary-uid#gl-raw-uid2">raw UID2</Link> that is unique to that publisher. This mismatched raw UID2 will not correspond to the one used by other participants for the same DII, meaning the publisher's tokens will not match up with those from other publishers, data providers, or advertisers' CRM uploads.
+When publishers generate UID2 tokens by providing DII, in some cases the resulting UID2 token appears valid but is not. This is because the normalization or hashing steps are not performed correctly. Because UID2 uses the normalized and hashed form of DII to derive the token, an error in either step produces a UID2 token and underlying <Link href="../ref-info/glossary-uid#gl-raw-uid2">raw UID2</Link> that do not correspond to the correct values generated from the same DII by other participants.
 
 ## Prerequisites
 
@@ -27,25 +27,28 @@ If you do not have these, see [API Keys](../portal/api-keys.md) for instructions
 
 ## Using the Token Validator
 
-Enter your **API Key** (Client Key) and **Client Secret** in the fields at the top of the Token Validation section.
+To use the token validator, follow these steps:
 
-Select the **Operator** (environment) you want to validate against. For information about UID2 environments, see [Environments](../getting-started/gs-environments.md).
+1. In the fields at the top of the Token Validation section, enter your **API Key** (Client Key) and **Client Secret**.
+2. Select the **Operator** (environment) you want to validate against. For information about UID2 environments, see [Environments](../getting-started/gs-environments.md).
 
 ### Validate a Single Token
+
+To validate a single token, follow these steps:
 
 1. Under **Input Mode**, select **Single Validation**.
 2. In the **Identifier** field, enter the DII you used to generate the token. This can be:
    - A raw email address
    - A raw phone number
-   - A Base64-encoded email hash
-   - A Base64-encoded phone hash
+   - A normalized and then Base64-encoded email hash
+   - A normalized and then Base64-encoded phone hash
 3. Select the identifier type that matches your input.
 4. In the **Token** field, paste the UID2 token you want to validate.
 5. Click **Validate Tokens**.
 
 ### Validate Multiple Tokens (CSV)
 
-To validate a batch of token-identifier pairs:
+To validate a batch of token-identifier pairs, follow these steps:
 
 1. Under **Input Mode**, select **CSV**.
 2. Prepare a CSV file with the following columns: 

--- a/docs/ref-info/updates-doc.md
+++ b/docs/ref-info/updates-doc.md
@@ -24,6 +24,20 @@ Use the Tags toolbar to view a subset of documentation updates.
 
 The following documents were released in the second quarter of 2026.
 
+<CustomTagsContainer tags="Reference">
+
+### UID2 Token Validator
+
+April 24, 2026
+
+We've added a new reference page for the [UID2 Token Validator](ref-token-validator.md), a web-based tool that validates UID2 tokens against their source DII so you can confirm that your token generation process is correct.
+
+For details, see [UID2 Token Validator](ref-token-validator.md).
+
+<!-- UID2-6592 -->
+
+</CustomTagsContainer>
+
 <CustomTagsContainer tags="Endpoints">
 
 ### Rate Limiting and Parallel Request Updates for POST /identity/map

--- a/sidebars.js
+++ b/sidebars.js
@@ -446,10 +446,10 @@ const sidebars = {
     'endpoints/post-token-generate',
     'endpoints/post-token-validate',
     'endpoints/post-token-refresh',
-    'sharing/sharing-bid-stream'
-    ),
+    'ref-info/ref-token-validator'
+  ),
 
-  sidebarDSPs: removeItems(fullSidebar, 
+  sidebarDSPs: removeItems(fullSidebar,
     'overviews/overview-publishers',
     'overviews/overview-advertisers',
     'overviews/overview-data-providers',
@@ -489,11 +489,10 @@ const sidebars = {
     'guides/integration-databricks',
     'guides/integration-aws-entity-resolution',
     'guides/advertiser-dataprovider-endpoints',
-    'sharing/sharing-bid-stream',
     'ref-info/ref-token-validator'
   ),
 
-  sidebarDataProviders: removeItems(fullSidebar, 
+  sidebarDataProviders: removeItems(fullSidebar,
     'overviews/overview-publishers',
     'overviews/overview-advertisers',
     'overviews/overview-dsps',
@@ -530,7 +529,6 @@ const sidebars = {
     'endpoints/post-token-generate',
     'endpoints/post-token-validate',
     'endpoints/post-token-refresh',
-    'sharing/sharing-bid-stream',
     'ref-info/ref-token-validator'
   ),
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -446,6 +446,7 @@ const sidebars = {
     'endpoints/post-token-generate',
     'endpoints/post-token-validate',
     'endpoints/post-token-refresh',
+    'sharing/sharing-bid-stream',
     'ref-info/ref-token-validator'
   ),
 
@@ -489,6 +490,7 @@ const sidebars = {
     'guides/integration-databricks',
     'guides/integration-aws-entity-resolution',
     'guides/advertiser-dataprovider-endpoints',
+    'sharing/sharing-bid-stream',
     'ref-info/ref-token-validator'
   ),
 
@@ -529,6 +531,7 @@ const sidebars = {
     'endpoints/post-token-generate',
     'endpoints/post-token-validate',
     'endpoints/post-token-refresh',
+    'sharing/sharing-bid-stream',
     'ref-info/ref-token-validator'
   ),
 


### PR DESCRIPTION
## Summary
- Ports the editorial and technical edits applied in [EUID-docs#401](https://github.com/European-Unified-ID/EUID-docs/pull/401) back to the equivalent UID2 token validator reference page.
- Adds a Documentation Updates entry announcing the new [UID2 Token Validator](../uid2docs/docs/ref-info/ref-token-validator.md) tool and page.
- Sidebar cleanup: removes the `sharing/sharing-bid-stream` exclusions and adds `ref-info/ref-token-validator` to the Advertisers sidebar exclusions (was missing).

[UID2-6960](https://thetradedesk.atlassian.net/browse/UID2-6960)

## Test plan
- [ ] Build the site and skim the UID2 Token Validator page for the reworded Overview, numbered Using the Token Validator steps, and \"normalized and then Base64-encoded\" bullets.
- [ ] Verify the new Documentation Updates entry renders under Q2 2026 with the Reference tag.
- [ ] Verify the token validator page does not appear in the Advertisers sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)