### PR TITLE
UID2-7488: clarify opt-out webhook timestamp unit (Unix seconds)

### DIFF
--- a/docs/guides/dsp-guide.md
+++ b/docs/guides/dsp-guide.md
@@ -49,7 +49,11 @@ The UID2 service sends the following data within seconds of a user's opt-out, wh
 | Parameter | Description |
 | :--- | :--- |
 | `identity` | The raw UID2 for the user who opted out. |
-| `timestamp` | The time when the user opted out (for information only). |
+| `timestamp` | The time when the user opted out, as a <a href="../ref-info/glossary-uid#gl-unix-time">Unix</a> timestamp in **seconds** (for information only). |
+
+:::note
+The opt-out webhook `timestamp` is in **seconds**. This is different from the `opted_out_since` value returned by the [POST&nbsp;/optout/status](../endpoints/post-optout-status.md) endpoint, which is a Unix timestamp in **milliseconds**.
+:::
 
 The DSP must respond to the opt-out data with a 200 response code.
 


### PR DESCRIPTION
## What

Clarifies the unit of the `timestamp` parameter in the opt-out webhook table in the [DSP integration guide → Honor user opt-outs](https://unifiedid.com/docs/guides/dsp-guide#honor-user-opt-outs). The table previously said only "The time when the user opted out (for information only)" with no unit.

Changes:
- State that `timestamp` is a Unix timestamp in **seconds**.
- Add a `:::note` distinguishing it from `POST /optout/status`'s `opted_out_since`, which is in **milliseconds**.

## Why

A DSP integrating the opt-out webhook could not tell whether the value was Unix seconds or milliseconds. The ambiguity is real because the sibling `/optout/status` endpoint returns milliseconds, so a reader could reasonably assume the webhook matches — it does not.

## Source of truth (verified in code)

The webhook value is **Unix epoch seconds**:
- `IABTechLab/uid2-optout` `OptOutPartnerEndpoint.java` substitutes the `${OPTOUT_EPOCH}` macro (the guide's `%%timestamp%%`) directly with `String.valueOf(entry.timestamp)` — no conversion.
- `IABTechLab/uid2-shared` `OptOutEntry.java` documents the entry's timestamp field as `7 bytes -- timestamp (seconds)`; `uid2-optout` `OptOutServiceVerticle.java` writes `OptOutUtils.nowEpochSeconds()` = `Instant.now().getEpochSecond()`.
- Contrast: `IABTechLab/uid2-operator` `UIDOperatorVerticle.java` builds the `/optout/status` response via `Instant.ofEpochSecond(timestamp).toEpochMilli()` — deliberately milliseconds.

## Jira

https://thetradedesk.atlassian.net/browse/UID2-7488

🤖 Generated with [Claude Code](https://claude.com/claude-code)