### PR TITLE
UID2-7491: bump websocket-driver to 0.7.5 (CVE-2026-54466)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18731,9 +18731,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "fast-uri": ">=3.1.2",
     "shell-quote": "^1.8.4",
-    "ws": ">=7.5.11"
+    "ws": ">=7.5.11",
+    "websocket-driver": "^0.7.5"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

Remediates **CVE-2026-54466** (CRITICAL) in `websocket-driver` 0.7.4 → **0.7.5**, flagged by the scheduled Trivy vulnerability scan.

## Fix

Adds an npm `overrides` entry `"websocket-driver": "^0.7.5"` and regenerates `package-lock.json`. This matches the existing convention in this repo of pinning transitive security fixes in the `overrides` block (`ws`, `shell-quote`, `minimatch`, …).

## Impact assessment

`websocket-driver` is a **dev-only transitive dependency**:

```
@docusaurus/core → webpack-dev-server → sockjs / faye-websocket → websocket-driver
```

`webpack-dev-server` only runs during local `npm start`; the deployed site is a static `docusaurus build`, so the "message corruption via protocol abuse" attack (which needs a live WS server) is **not reachable in production**. A clean patch-level fix is available, so we upgrade rather than suppress — this permanently clears the CRITICAL alarm instead of a time-limited `.trivyignore`.

Jira: UID2-7491

🤖 Generated with [Claude Code](https://claude.com/claude-code)