### PR TITLE
UID2-7589: update AKS guide Kubernetes version from 1.33 to 1.36

### DIFF
--- a/docs/guides/operator-guide-aks-enclave.md
+++ b/docs/guides/operator-guide-aks-enclave.md
@@ -280,7 +280,7 @@ az aks create \
     --resource-group ${RESOURCE_GROUP} \
     --name ${AKS_CLUSTER_NAME} \
     --location ${LOCATION} \
-    --kubernetes-version 1.33 \
+    --kubernetes-version 1.36 \
     --network-plugin azure \
     --network-policy calico \
     --vnet-subnet-id ${AKS_SUBNET_ID} \
@@ -297,7 +297,7 @@ az aks create \
     --os-sku Ubuntu
 ```
 :::note
-Be sure to use the latest supported Kubernetes version, using the `--kubernetes-version` flag. If you use an earlier version, you must enable Long-Term Support (LTS). For details, see [Long-term support for Azure Kubernetes Service (AKS) versions](https://learn.microsoft.com/en-us/azure/aks/long-term-support) in the Microsoft documentation.
+Be sure to use the latest supported Kubernetes version, using the `--kubernetes-version` flag. The version shown above is only an example: Azure moves each Kubernetes minor version out of standard support about 12 months after its release, and cluster creation then fails with `K8sVersionNotSupported`. To list the versions currently available in your region, run `az aks get-versions --location ${LOCATION}`. If you use a version that is no longer in standard support, you must enable Long-Term Support (LTS). For details, see [Long-term support for Azure Kubernetes Service (AKS) versions](https://learn.microsoft.com/en-us/azure/aks/long-term-support) in the Microsoft documentation.
 :::
 
 #### Get the principal ID of the managed identity


### PR DESCRIPTION
## What

Updates the AKS Private Operator integration guide (`docs/guides/operator-guide-aks-enclave.md`):

* `--kubernetes-version 1.33` → `1.36` in the `az aks create` example.
* Expands the accompanying note so readers are not dependent on the example staying current.

## Why

Azure gives each Kubernetes minor version 12 months of standard support after GA. 1.33 went GA in Jun 2025 and reached **end of life in Jul 2026**, so it has dropped to Long-Term Support only. A private operator following this guide verbatim now hits:

```
ERROR: (K8sVersionNotSupported) ... is on version 1.33.13, which is only available for
Long-Term Support (LTS). To enable LTS on the cluster, see https://aka.ms/aks/enable-lts.
Code: K8sVersionNotSupported
```

This surfaced as a nightly `Publish All Operators` failure in `uid2-operator` (the E2E AKS setup script carried the same stale pin — fixed in [uid2-shared-actions #258](https://github.com/IABTechLab/uid2-shared-actions/pull/258)). The same pin in this guide is the client-facing half of the problem, so partners standing up a new AKS private operator would fail at cluster creation.

## Why 1.36

Confirmed against a live subscription with `az aks get-versions --location westus3`, not just the published calendar:

| Version | Support plans offered | Notes |
| --- | --- | --- |
| 1.33 | `AKSLongTermSupport` only | `KubernetesOfficial` withdrawn — the cause of the error |
| 1.34 | `KubernetesOfficial` + LTS | EOL Nov 2026 |
| 1.35 | `KubernetesOfficial` + LTS | EOL Mar 2027 |
| **1.36** | **`KubernetesOfficial` + LTS** | EOL Jun 2027, patches to 1.36.2 |

1.37 is not offered in the region yet. 1.36 keeps this guide aligned with the version the operator E2E now uses.

## Note change

The existing note already said "be sure to use the latest supported Kubernetes version", but the stale example directly contradicted it, and a reader had no way to act on the advice. It now also:

* explains that Azure moves each minor out of standard support on a ~12-month cadence,
* names `K8sVersionNotSupported` so anyone who hits the error can search for it and land here,
* gives `az aks get-versions --location ${LOCATION}` for finding what is currently available in their own region.

## Scope

English only — the Japanese translation is handled by the translation pipeline and has been deliberately left untouched.

No structural, navigation, or formatting changes; the diff is confined to two lines in one file.

Ticket: [UID2-7589](https://thetradedesk.atlassian.net/browse/UID2-7589)

🤖 Generated with [Claude Code](https://claude.com/claude-code)