### PR TITLE
UID2-7633: suppress CVE-2026-18446 in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,9 @@
 # for more details
 # e.g. 
 # CVE-2022-3996
+
+# CVE-2026-18446 — fast-uri (npm) (HIGH).
+# Not exploitable here: package.json:71 pins fast-uri ^3.1.4 in overrides; lock resolves 3.1.4
+# only under ajv-formats/schema-utils. No source import.
+# See: UID2-7633
+CVE-2026-18446 exp:2026-09-06


### PR DESCRIPTION
Suppresses **CVE-2026-18446** (HIGH, `fast-uri (npm)`) — present in the image but not reachable from this service. Expiry **2026-09-06** (1 month). No code fix.

**Why:** The CVE is a host-confusion parser desync: fast-uri parses a backslash authority introducer (\\, /\, \/) with no authority while Node's WHATWG URL/fetch treats \ as /, so an app using fast-uri to enforce host-based policy before fetch can be steered off-allowlist. Exploitation requires the app to parse untrusted URLs with fast-uri for security decisions (allowlist/SSRF/redirect/proxy) and then pass them to fetch/undici/http. In all five repos fast-uri is present only as a transitive dependency of ajv (declared solely in overrides pins), used for JSON-schema $ref/$id resolution during docs/webpack builds and schema validation. No repo imports fast-uri directly and none use it for host-based URL policy, so the vulnerable path is unreachable despite the resolved 3.1.4 being below the 3.1.5 fix.

**Evidence:** package.json:69 pins fast-uri ^3.1.4 in overrides block only; lock resolves to 3.1.4 solely as transitive dep of ajv (node_modules/ajv-formats/node_modules/fast-uri, schema-utils). No import/require of fast-uri in any source file. package.json:24 pins fast-uri >=3.1.2 in overrides/resolutions; no node_modules/fast-uri resolved entry and no source import — build-tooling pin only. package.json:273 pins fast-uri ^3.1.4 in overrides; lock resolves node_modules/fast-uri 3.1.4 transitively under ajv instances (webpack plugins, eslint, table, objection). No direct fast-uri import in source; used only for ajv JSON-schema $ref resolution, not host-policy URL parsing. package.json:71 pins fast-uri ^3.1.4 in overrides; lock resolves 3.1.4 only under ajv-formats/schema-utils. No source import. preview/package.json:71 pins fast-uri ^3.1.4 in overrides; lock resolves 3.1.4 only under ajv-formats/schema-utils. No source import.

Reachability alone determines suppress-vs-fix — a fixed version existing upstream does not make an unreachable path exploitable. Change the expiry in review if you want a different window.

<details>
<summary>Full triage report</summary>

### CVE-2026-18446 — fast-uri host confusion via backslash authority introducer

#### What the CVE is
`fast-uri` (npm) v4.1.1 and earlier require a literal `//` to recognize a URI authority. A reference that uses `\\`, `/\`, or `\/` as the authority introducer is parsed with **no authority** — the sequence and everything after it fold into the path. Node's native WHATWG `URL` (used by `fetch()`, `undici`, and Node's `http`/`https` clients) instead treats `\` as interchangeable with `/` for special schemes, so the two parsers extract **different hosts** from the same input (e.g. `\\evil.com/path` resolves to a trusted-host path under fast-uri but to `https://evil.com/path` under WHATWG URL).

**Impact class:** integrity (CVSS `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N`). The risk materializes only when an application uses fast-uri to **enforce host-based policy** (allowlist/denylist, loopback/SSRF filtering, redirect validation, outbound-proxy routing) and then passes the same URL into a Node URL/`fetch` consumer — the parse/use desync steers the request to an unintended destination.

Fixed in **2.4.4, 3.1.5, 4.1.2**.

#### How it affects our services (based on code search)
fast-uri was flagged in five repos: **EUID-docs, uid2-examples, uid2-self-serve-portal, uid2docs, uid2-docs-preview**. In each:

- fast-uri is declared **only inside an `overrides` block** (a security pin alongside shell-quote, qs, minimatch, etc.), never as a first-class `dependency`/`devDependency`.
- The lockfiles resolve it to **v3.1.4** (below the 3.1.5 fix), and it appears **only as a transitive dependency of `ajv`/`ajv-formats`** (via `schema-utils`, webpack plugins, eslint, `table`, and — in the portal — the `objection` ORM). `ajv` uses fast-uri strictly to resolve JSON-schema `$ref`/`$id` URIs.
- **No source file in any repo imports or requires `fast-uri`** (grep over `*.js/ts/jsx/tsx/mjs/cjs` returned nothing outside lockfiles/node_modules).

These repos are documentation sites and example/portal frontends. None uses fast-uri to parse untrusted URLs for host-based security decisions before handing them to `fetch`/`undici`/`http`. The only exerciser is ajv's internal schema-reference resolution during build and validation, which does not consume attacker-controlled URLs as security-sensitive hosts. The specific attack vector described in the advisory is therefore **not reachable**.

#### Decision
**not_affected.** The vulnerable code path — using fast-uri's authority parsing to enforce host policy ahead of a WHATWG-URL/fetch consumer — is not present. fast-uri is a transitive, build/validation-only dependency of ajv with no direct usage. A fixed version being available does not change this verdict.

**Recommended action:** suppress. If a maintainer prefers to clear the scanner noise anyway, bumping the fast-uri `overrides` pin to `^3.1.5` is a zero-risk cleanup, but it is not security-required here.

</details>

---
_Opened by uid2-vul-scan-agent (general_use_claude-opus-4-8), verdict confidence high. Please sanity-check the reachability argument before approving._
